### PR TITLE
add test code to check if file exists

### DIFF
--- a/test/test_openhrp3.py
+++ b/test/test_openhrp3.py
@@ -57,6 +57,11 @@ class TestCompile(unittest.TestCase):
         self.check_if_file_exists_from_rospack("share/OpenHRP-3.1/sample/project")
         # self.check_if_file_exites_from_prefix("share/openhrp3/share/OpenHRP-3.1/sample/project")
 
+        # https://code.google.com/p/hrpsys-base/source/browse/trunk/idl/CMakeLists.txt#118
+        self.check_if_file_exists("idl_dir",            "OpenHRP/OpenHRPCommon.idl")
+        # https://code.google.com/p/hrpsys-base/source/browse/trunk/sample/PA10/PA10.conf.in#1
+        self.check_if_file_exists_from_rospack("share/OpenHRP-3.1/sample/model/PA10/pa10.main.wrl")
+
     def test_files_for_hrpsys_ros_bridge(self):
         # https://github.com/start-jsk/rtmros_common/blob/master/hrpsys_ros_bridge/test/test-samplerobot.py#L63
         self.check_if_file_exists_from_rospack("share/OpenHRP-3.1/sample/controller/SampleController/etc/Sample.pos")

--- a/test/test_openhrp3.py
+++ b/test/test_openhrp3.py
@@ -28,6 +28,45 @@ class TestCompile(unittest.TestCase):
         if os.path.exists(os.path.join(openhrp3_path, "bin")) :
             self.PKG_CONFIG_PATH='PKG_CONFIG_PATH=%s/lib/pkgconfig:$PKG_CONFIG_PATH'%(openhrp3_path)
 
+    def pkg_config_variable(self, var):
+        return check_output("%s pkg-config openhrp3.1 --variable=%s"%(self.PKG_CONFIG_PATH, var), shell=True).rstrip()
+
+    def check_if_file_exists(self, var, fname):
+        pkg_var = var
+        pkg_dname = self.pkg_config_variable(pkg_var)
+        pkg_path = os.path.join(pkg_dname, fname)
+        pkg_ret = os.path.exists(pkg_path)
+        self.assertTrue(pkg_ret, "pkg-config openhrp3.1 --variable=%s`/%s (%s) returns %r"%(pkg_var, fname, pkg_path, pkg_ret))
+
+    def test_config_variables(self):
+        # self.check_if_file_exists("prefix",             "") # not defined
+        # self.check_if_file_exists("exec_prefix",        "") # not defined
+        self.check_if_file_exists("idl_dir",            "OpenHRP/OpenHRPCommon.idl")
+
+    def check_if_file_exists_from_rospack(self, fname):
+        pkg_dname = check_output(['rospack','find','openhrp3']).rstrip()
+        pkg_path = os.path.join(pkg_dname, fname)
+        pkg_ret = os.path.exists(pkg_path)
+        self.assertTrue(pkg_ret, "`rospack find openhrp3`(%s) returns %r"%(pkg_path, pkg_ret))
+
+    def check_if_file_exites_from_prefix(self, fname):
+        self.check_if_file_exists("prefix", fname)
+
+    def test_files_for_hrpsys(self):
+        # https://github.com/start-jsk/hrpsys/blob/master/catkin.cmake#L125
+        self.check_if_file_exists_from_rospack("share/OpenHRP-3.1/sample/project")
+        # self.check_if_file_exites_from_prefix("share/openhrp3/share/OpenHRP-3.1/sample/project")
+
+    def test_files_for_hrpsys_ros_bridge(self):
+        # https://github.com/start-jsk/rtmros_common/blob/master/hrpsys_ros_bridge/test/test-samplerobot.py#L63
+        self.check_if_file_exists_from_rospack("share/OpenHRP-3.1/sample/controller/SampleController/etc/Sample.pos")
+
+        # https://github.com/start-jsk/rtmros_common/blob/master/hrpsys_ros_bridge/catkin.cmake#L141
+        self.check_if_file_exists("idl_dir",            "../sample/model/PA10/pa10.main.wrl")
+        self.check_if_file_exists("idl_dir",            "../sample/model/sample1.wrl")
+        self.check_if_file_exists_from_rospack("share/OpenHRP-3.1/sample/model/PA10/pa10.main.wrl")
+        self.check_if_file_exists_from_rospack("share/OpenHRP-3.1/sample/model/sample1.wrl")
+
     ## test 1 == 1
     def test_compile_pkg_config(self):
         global PID


### PR DESCRIPTION
similar to issue discussed in https://github.com/start-jsk/openrtm_aist_core/issues/1

currently openhrp3.1.pc provides following information.

```
prefix=/home/k-okada/ros/groovy/rtm-ros-robotics/openrtm_common/openhrp3
exec_prefix=${prefix}/bin
libdir=${prefix}/lib
includedir=-I${prefix}/include/OpenHRP-3.1 -I/usr/include/eigen3
idl_dir=${prefix}/share/OpenHRP-3.1/idl
link_shared_files=-lhrpCollision-3.1 -lhrpModel-3.1 -lhrpPlanner-3.1 -lhrpUtil-3.1 
link_static_files=-lhrpCorbaStubSkel-3.1
link_depend_dirs=-L/usr/lib/atlas-base/atlas -L/home/k-okada/ros/groovy/rtm-ros-robotics/openrtm_common/openrtm_aist_core/openrtm_aist/lib 
link_depend_files=-lblas -llapack -lboost_filesystem-mt -lboost_signals-mt -lboost_program_options-mt -lboost_regex-mt -ljpeg -lpng -lz -luuid -ldl -lpthread -lomniORB4 -lomnithread -lomniDynamic4 -lRTC -lcoil 
link_depend_options=-export-dynamic 
cflag_defs=
cflag_options=-Wall -fPIC -g -I/home/k-okada/ros/groovy/rtm-ros-robotics/openrtm_common/openrtm_aist_core/openrtm_aist/include -I/home/k-okada/ros/groovy/rtm-ros-robotics/openrtm_common/openrtm_aist_core/openrtm_aist/include/coil-1.1 -I/home/k-okada/ros/groovy/rtm-ros-robotics/openrtm_common/openrtm_aist_core/openrtm_aist/include/openrtm-1.1 -I/home/k-okada/ros/groovy/rtm-ros-robotics/openrtm_common/openrtm_aist_core/openrtm_aist/include/openrtm-1.1/rtm/idl 
```
