### PR TITLE
Give installed libraries execute permissions

### DIFF
--- a/catkin.cmake
+++ b/catkin.cmake
@@ -111,7 +111,7 @@ endforeach()
 foreach(_lib_file ${_lib_files})
   get_filename_component(_lib_file_path ${_lib_file} PATH)
   string(REPLACE "${CATKIN_DEVEL_PREFIX}/lib" "" _lib_file_path ${_lib_file_path})
-  install(FILES ${_lib_file} DESTINATION ${CATKIN_GLOBAL_LIB_DESTINATION}/${_lib_file_path})
+  install(PROGRAMS ${_lib_file} DESTINATION ${CATKIN_GLOBAL_LIB_DESTINATION}/${_lib_file_path})
 endforeach()
 ## done copy libs
 


### PR DESCRIPTION
All shared object libraries should have execute permissions. Using install will default the permissions to be like a normal file, which typically doesn't have execute permissions.

There is no cmake directive for installing libraries in this way, but the PROGRAMS directive is the same as FILES except that it gives execute permissions to installed files.

This was caught as a packaging error on Fedora.

Thanks!
